### PR TITLE
update hyper to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,6 @@ keywords = ["hyper", "unix", "sockets", "http"]
 license = "MIT"
 
 [dependencies]
-hyper = "0.7"
+hyper = "0.8"
 unix_socket = "0.5"
 url = "0.5"


### PR DESCRIPTION
I feel kind of stupid to do even a pull request for this... 

What about bumping the version of hyper to 0.8 (or maybe >= 0.7)? I needed to fork, so that I can test and use that in my own project like that, and I'd like not do that in the future.

*Note:* I have only tested the client part!