### PR TITLE
Enable using UnixListener and UnixStream from stdlib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,12 @@ repository = "https://github.com/softprops/hyperlocal"
 keywords = ["hyper", "unix", "sockets", "http"]
 license = "MIT"
 
+[features]
+default = ["external_unix_socket"]
+external_unix_socket = ["unix_socket"]
+
 [dependencies]
 hyper = "0.9"
 rustc-serialize = "0.3"
-unix_socket = "0.5"
+unix_socket = { version = "0.5", optional = true}
 url = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 //! for how to configure hyper servers
 
 extern crate hyper;
+#[cfg(external_unix_socket)]
 extern crate unix_socket;
 extern crate url;
 extern crate rustc_serialize;
@@ -17,9 +18,14 @@ use std::io::{self, Read, Write};
 use std::path::Path;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::time::Duration;
+#[cfg(external_unix_socket)]
 use unix_socket::{UnixListener, UnixStream};
+#[cfg(not(external_unix_socket))]
+use std::os::unix::net::{UnixListener, UnixStream};
+
 use url::Url;
 use url::ParseError as UrlError;
+
 
 use rustc_serialize::hex::{ToHex, FromHex};
 


### PR DESCRIPTION
With new version of rust (1.10) it's now possible to use UnixListener and UnixStream from stdlib.
This patch allows to disable dependency on external crate.
Using external crate is enabled by default to preserve compatibility.