### PR TITLE
update hyper crate to v0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ default = ["external_unix_socket"]
 external_unix_socket = ["unix_socket"]
 
 [dependencies]
-hyper = "0.9"
+hyper = "0.10"
 rustc-serialize = "0.3"
 unix_socket = { version = "0.5", optional = true}
 url = "1.0"


### PR DESCRIPTION
Hi,

This PR updates `hyper` to `v0.10` which removes the dependency to `openssl` (allowing more flexibility).

This can come handy for shiplift (or other libs using shiplift) to update to a newer version of `openssl` and avoid the dependency clash on `openssl-sys`.

Some context here: https://github.com/hyperium/hyper/issues/985

Signed-off-by: Alexandre Beslic <abeslic@abronan.com>