### PR TITLE
Allow driving server using user-provided runtime.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 //!
 //! See the `hyperlocal::UnixConnector` docs for how to configure hyper clients and the `hyperlocal::server::Http` docs
 //! for how to configure hyper servers
+
 extern crate futures;
 extern crate hex;
 extern crate hyper;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4,121 +4,328 @@
 use std::error;
 use std::fmt;
 use std::io;
-use std::os::unix::net::SocketAddr;
+use std::os::unix::net::{SocketAddr, UnixListener as StdUnixListener};
 use std::path::Path;
 
 // Third party
-use futures::future::Future;
-use futures::stream::Stream;
+use futures::{Async, Future, Poll, Stream};
 use hyper::body::Payload;
-use hyper::server::conn::Http as HyperHttp;
+use hyper::server::conn::{Connection as HyperConnection, Http as HyperHttp};
 use hyper::service::{NewService, Service};
 use hyper::Body;
-use tokio::runtime::Runtime;
-use tokio_uds::UnixListener;
+use tokio::{reactor::Handle, runtime::Runtime};
+use tokio_uds::{Incoming as UnixIncoming, UnixListener, UnixStream};
 
-/// An instance of a server created through `Http::bind`.
-//
-/// This structure is used to create instances of Servers to spawn off tasks
-/// which handle a connection to an HTTP server.
-pub struct Server<S>
-where
-    S: NewService<ReqBody = Body> + Send + 'static,
-{
-    new_service: S,
-    runtime: Runtime,
-    listener: UnixListener,
-}
-
-impl<S> Server<S>
-where
-    S: NewService<ReqBody = Body, ResBody = Body, Error = io::Error> + Send + Sync + 'static,
-    S::InitError: fmt::Display,
-    <S::Service as Service>::Future: Send,
-    <S as NewService>::Service: Send,
-    <S as NewService>::Future: Send,
-{
-    /// Return the of the underlying socket address this server is listening on
-    pub fn local_addr(&self) -> io::Result<SocketAddr> {
-        self.listener.local_addr()
-    }
-
-    /// Start listening for incomming connections
-    pub fn run(self) -> io::Result<()> {
-        let Server {
-            new_service,
-            runtime,
-            listener,
-        } = self;
-
-        let server = listener.incoming().for_each(move |sock| {
-            new_service
-                .new_service()
-                .map_err(|e| {
-                    io::Error::new(
-                        io::ErrorKind::Other,
-                        format!("failed to create service: {}", e),
-                    )
-                }).and_then(|service| {
-                    HyperHttp::new()
-                        .serve_connection(sock, service)
-                        .map_err(|e| {
-                            io::Error::new(
-                                io::ErrorKind::Other,
-                                format!("failed to serve connection: {}", e),
-                            )
-                        })
-                })
-        });
-
-        // ::hyper::rt::run(server)
-        runtime.block_on_all(server)
-    }
-}
-
-/// A type that provides a factory interface for creating
-/// unix socket based Servers
+/// An instance of a unix domain socket server created through `Server::bind`.
 ///
-/// # examples
+/// # Examples
 ///
-/// ```no_run
+/// ```rust
 /// extern crate hyper;
 /// extern crate hyperlocal;
 ///
-/// //let server = hyperlocal::Http::new().bind(
-///  // "path/to/socket",
-///  //  || Ok(HelloWorld)
-/// //)
+/// use hyper::service::service_fn;
+/// use hyperlocal::server::Server as UdsServer;
 ///
+/// # match std::fs::remove_file("hyperlocal_test_echo_server_1.sock") {
+/// #     Ok(()) => (),
+/// #     Err(ref err) if err.kind() == std::io::ErrorKind::NotFound => (),
+/// #     Err(err) => panic!("{}", err),
+/// # }
+/// #
+/// let echo_server = UdsServer::bind(
+///    "hyperlocal_test_echo_server_1.sock",
+///    || service_fn(|req| Ok::<_, hyper::Error>(hyper::Response::new(req.into_body())))
+/// ).unwrap();
+/// ```
+pub struct Server<S> {
+    serve: Serve<S>,
+}
+
+impl<S> Server<S> {
+    /// Binds a new server instance to a unix domain socket path.
+    ///
+    /// If the provided path exists, this method will return an error.
+    pub fn bind<P>(path: P, new_service: S) -> io::Result<Server<S>>
+    where
+        P: AsRef<Path>,
+        S: NewService<ReqBody = Body>,
+        S::ResBody: Payload,
+        S::Service: Send,
+        S::Error: Into<Box<error::Error + Send + Sync>>,
+        <S::Service as Service>::Future: Send + 'static,
+    {
+        let protocol = Http::new();
+        let serve = protocol.serve_path(path, new_service)?;
+        Ok(Server {
+            serve,
+        })
+    }
+
+    /// Return the local address of the underlying socket that this server is listening on.
+    pub fn local_addr(&self) -> &SocketAddr {
+        self.serve.incoming.local_addr()
+    }
+
+    /// Start a new tokio runtime, and drive this server on it.
+    pub fn run(self) -> io::Result<()>
+    where
+        S: NewService<ReqBody = Body> + Send + 'static,
+        S::Future: Send + 'static,
+        S::Service: Send,
+        S::InitError: fmt::Display,
+        <S::Service as Service>::ResBody: Payload,
+        <S::Service as Service>::Future: Send + 'static,
+    {
+        let runtime = Runtime::new()?;
+
+        runtime.block_on_all(
+            self.serve.for_each(|connecting| {
+                connecting
+                .map_err(|e| {
+                    io::Error::new(
+                        io::ErrorKind::Other,
+                        format!("failed to serve connection: {}", e),
+                    )
+                })
+                .and_then(|connection| connection.map_err(|e| {
+                    io::Error::new(
+                        io::ErrorKind::Other,
+                        format!("failed to serve connection: {}", e),
+                    )
+                }))
+            })
+        )
+    }
+}
+
+/// A stream mapping incoming connections to new services.
+///
+/// Yields `Connecting`s that are futures that should be put on a reactor.
+pub struct Serve<S> {
+    incoming: Incoming,
+    new_service: S,
+    protocol: HyperHttp,
+}
+
+impl<S> Stream for Serve<S>
+where
+    S: NewService<ReqBody = Body>,
+{
+    type Item = Connecting<S::Future>;
+    type Error = <UnixIncoming as Stream>::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        match self.incoming.poll()? {
+            Async::Ready(Some(stream)) => {
+                let service_future = self.new_service.new_service();
+                Ok(Async::Ready(Some(Connecting {
+                    service_future,
+                    stream: Some(stream),
+                    protocol: self.protocol.clone(),
+                })))
+            },
+            Async::Ready(None) => Ok(Async::Ready(None)),
+            Async::NotReady => Ok(Async::NotReady),
+        }
+    }
+}
+
+/// A future building a new `Service` to a `Connection`.
+///
+/// Wraps the future returned from `NewService` into one that returns a `Connection`.
+pub struct Connecting<F> {
+    service_future: F,
+    stream: Option<UnixStream>,
+    protocol: HyperHttp,
+}
+
+impl<F> Future for Connecting<F>
+where
+    F: Future,
+    F::Item: Service<ReqBody = Body>,
+    <F::Item as Service>::ResBody: Payload,
+    <F::Item as Service>::Future: Send + 'static,
+{
+    type Item = HyperConnection<UnixStream, F::Item>;
+    type Error = F::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let service = match self.service_future.poll()? {
+            Async::Ready(service) => service,
+            Async::NotReady => return Ok(Async::NotReady),
+        };
+        let stream = self.stream.take().expect("polled after complete");
+        Ok(Async::Ready(self.protocol.serve_connection(stream, service)))
+    }
+}
+
+/// A lower-level method of creating a unix domain socket server.
+///
+/// This structure is used to manage connections yourself. If you don't need to do this,
+/// consider using the higher-level `Server::bind` API.
+///
+/// # Examples
+///
+/// ```rust
+/// extern crate hyper;
+/// extern crate hyperlocal;
+///
+/// use std::os::unix::net::UnixListener as StdUnixListener;
+/// use hyper::{Response, rt::{Future, Stream}, service::service_fn};
+/// use hyperlocal::server::{Http as UdsHttp, Incoming as UdsIncoming};
+///
+/// # match std::fs::remove_file("hyperlocal_test_echo_server_2.sock") {
+/// #     Ok(()) => (),
+/// #     Err(ref err) if err.kind() == std::io::ErrorKind::NotFound => (),
+/// #     Err(err) => panic!("{}", err),
+/// # }
+/// #
+/// let listener = StdUnixListener::bind("hyperlocal_test_echo_server_2.sock").unwrap();
+/// let incoming = UdsIncoming::from_std(listener, &Default::default()).unwrap();
+/// let serve = UdsHttp::new().serve_incoming(incoming, move || service_fn(|req| Ok::<_, hyper::Error>(Response::new(req.into_body()))));
+///
+/// let server = serve.for_each(|connecting| {
+///     connecting
+///     .then(|connection| {
+///         let connection = connection.unwrap();
+///         Ok::<_, hyper::Error>(connection)
+///     })
+///     .flatten()
+///     .map_err(|err| {
+///         std::io::Error::new(
+///             std::io::ErrorKind::Other,
+///             format!("failed to serve connection: {}", err),
+///         )
+///     })
+/// });
 /// ```
 #[derive(Clone)]
-pub struct Http;
+pub struct Http {
+    inner: HyperHttp,
+}
 
 impl Http {
     /// Creates a new instance of the HTTP protocol, ready to spawn a server or
     /// start accepting connections.
     pub fn new() -> Self {
-        Http
+        Http::from_hyper(HyperHttp::new())
     }
 
-    /// Binds a new server instance to a unix domain socket path
-    /// If the provided path exists this method will yield an error
-    pub fn bind<P, S, B>(&self, path: P, new_service: S) -> io::Result<Server<S>>
+    /// Creates a new instance of the HTTP protocol using the given hyper `Http`,
+    /// ready to spawn a server or start accepting connections.
+    pub fn from_hyper(hyper_http: HyperHttp) -> Self {
+        Http {
+            inner: hyper_http,
+        }
+    }
+
+    /// Bind the provided `path` with the default `Handle` and return `Serve`.
+    ///
+    /// This method will bind the unix domain socket path provided with
+    /// a new UDS listener ready to accept connections. Each connection will be
+    /// processed with the `new_service` object provided, creating a new service per
+    /// connection.
+    ///
+    /// If the provided path already exists, this method will return an error.
+    pub fn serve_path<P, S>(&self, path: P, new_service: S) -> io::Result<Serve<S>>
     where
         P: AsRef<Path>,
-        S: NewService<ReqBody = Body, ResBody = B> + Send + 'static,
-        S::Error: Into<Box<error::Error + Send + Sync>>,
+        S: NewService<ReqBody = Body>,
+        S::ResBody: Payload,
         S::Service: Send,
+        S::Error: Into<Box<error::Error + Send + Sync>>,
         <S::Service as Service>::Future: Send + 'static,
-        B: Payload,
     {
-        let runtime = Runtime::new()?;
-        let listener = UnixListener::bind(path.as_ref())?;
+        let incoming = Incoming::new(path, None)?;
+        Ok(self.serve_incoming(incoming, new_service))
+    }
 
-        Ok(Server {
-            runtime,
-            listener,
+    /// Bind the provided `path` with the `Handle` and return `Serve`.
+    ///
+    /// This method will bind the unix domain socket path provided with
+    /// a new UDS listener ready to accept connections. Each connection will be
+    /// processed with the `new_service` object provided, creating a new service per
+    /// connection.
+    ///
+    /// If the provided path already exists, this method will return an error.
+    pub fn serve_path_handle<P, S>(&self, path: P, handle: &Handle, new_service: S) -> io::Result<Serve<S>>
+    where
+        P: AsRef<Path>,
+        S: NewService<ReqBody = Body> + Send + 'static,
+        S::ResBody: Payload,
+        S::Service: Send,
+        S::Error: Into<Box<error::Error + Send + Sync>>,
+        <S::Service as Service>::Future: Send + 'static,
+    {
+        let incoming = Incoming::new(path, Some(handle))?;
+        Ok(self.serve_incoming(incoming, new_service))
+    }
+
+    /// Bind the provided stream of incoming `UnixStream` objects with a `NewService`.
+    pub fn serve_incoming<S>(&self, incoming: Incoming, new_service: S) -> Serve<S>
+    where
+        S: NewService<ReqBody = Body>,
+        S::ResBody: Payload,
+        S::Error: Into<Box<::std::error::Error + Send + Sync>>,
+    {
+        Serve {
+            incoming,
             new_service,
+            protocol: self.inner.clone(),
+        }
+    }
+}
+
+impl From<HyperHttp> for Http {
+    fn from(hyper_http: HyperHttp) -> Self {
+        Http::from_hyper(hyper_http)
+    }
+}
+
+/// A stream of unix domain socket connections.
+pub struct Incoming {
+    inner: UnixIncoming,
+    local_addr: SocketAddr,
+}
+
+impl Incoming {
+    /// Bind a listener to the provided `path` with the provided `Handle`.
+    ///
+    /// If the `Handle` is `None`, the current runtime handle is used.
+    pub fn new<P>(path: P, handle: Option<&Handle>) -> io::Result<Self> where P: AsRef<Path> {
+        let listener = StdUnixListener::bind(path)?;
+        match handle {
+            Some(handle) => Incoming::from_std(listener, handle),
+            None => {
+                let handle = Handle::current();
+                Incoming::from_std(listener, &handle)
+            },
+        }
+    }
+
+    /// Wrap the provided already-bound listener in a `tokio_uds` listener using the provided `Handle`.
+    pub fn from_std(listener: StdUnixListener, handle: &Handle) -> io::Result<Self> {
+        let listener = UnixListener::from_std(listener, handle)?;
+        let local_addr = listener.local_addr()?;
+        let inner = listener.incoming();
+        Ok(Incoming {
+            inner,
+            local_addr,
         })
+    }
+
+    /// Get the local address bound to this listener.
+    pub fn local_addr(&self) -> &SocketAddr {
+        &self.local_addr
+    }
+}
+
+impl Stream for Incoming {
+    type Item = <UnixIncoming as Stream>::Item;
+    type Error = <UnixIncoming as Stream>::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        self.inner.poll()
     }
 }


### PR DESCRIPTION
This makes the API more similar to hyper 0.12. Specifically, it allows the user
to use `server::Http::serve_*` for more fine-grained handling of
incoming connections. The existing `server::Server::run` still exists to allow
an easy way of synchronously starting up a server on a new tokio runtime.

Other changes:

- Fix and enable doctests on Server and Http.

- Fix server example to delete the socket if it exists before binding to it,
  so that it can be run more than once.

---

Note that this has semver-major breaking changes. `Http::bind` is now `Server::bind` (similar to `hyper::Server`), `Server::local_addr` always succeeds, and some of the generic bounds are different.