### PR TITLE
Add parenthesis to into_body method

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let client = Client::unix();
 
-    let response_body = client.get(url).await?.into_body;
+    let response_body = client.get(url).await?.into_body();
     
     let bytes = response_body
         .try_fold(Vec::default(), |mut buf, bytes| async {


### PR DESCRIPTION
When trying to run the code in the README I got this error:

```
 let response_body = client.get(url).await?.into_body;
   |                                                ^^^^^^^^^ help: use parentheses to call the method: `into_body()`
```
Added the parenthesis fixed it as it stated.