### PR TITLE
Make the wrapper type for Uri cloneable

### DIFF
--- a/src/uri.rs
+++ b/src/uri.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 ///
 /// let uri: HyperUri = Uri::new("/tmp/hyperlocal.sock", "/").into();
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Uri {
     hyper_uri: HyperUri,
 }


### PR DESCRIPTION
The `Uri` type does not currently derive `Clone`. The Uri from hyper being wrapped does support clone so looks like there is no reason the hyperlocal type should not as well.

Since building HTTP requests can take the URI as a moved value, it is convenient to be able to clone the type if building multiple requests. Otherwise you may need to explicitly instantiate a new Uri each time.