### PR TITLE
Only use alloc feature of futures-util

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ hex = "0.4"
 hyper = { version = "0.14", features = ["server", "client", "http1", "runtime"] }
 tokio = { version = "1.0", features = ["rt-multi-thread", "net"] }
 pin-project = "1.0"
-futures-util = "0.3"
+futures-util = { version = "0.3", default-features = false, features = [ 'alloc' ] }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["rt-multi-thread", "net", "macros", "io-std", "io-util"] }


### PR DESCRIPTION
I'm sorry for PR without issue. This fix is very small so I made Pull Request.

This crate uses `futures-util` with default-features so `futures-util` of this crate depends on more crates (e.g. `futures-macro`) than `futures-util` of hyper.
That make build slower so I remove default-features and make depends on fewer features of `futures-util`.