### PR TITLE
export `UnixStream` for clients

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -14,6 +14,7 @@ use std::{
 };
 use tokio::io::ReadBuf;
 
+/// A stream of the client connection to a server.
 #[pin_project]
 #[derive(Debug)]
 pub struct UnixStream {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 #[cfg(feature = "client")]
 mod client;
 #[cfg(feature = "client")]
-pub use client::{UnixClientExt, UnixConnector};
+pub use client::{UnixClientExt, UnixConnector, UnixStream};
 
 #[cfg(feature = "server")]
 mod server;


### PR DESCRIPTION
Hi there!

I'm making some good use of this adapter to integrate hyper HTTP client connections with some upgrading to WebSockets via tungstenite and while creating my wrapper client I found myself needing to express the underlying `Stream` type over which hyper was communicating. In the typical TCP/HTTP case this would be a `TcpStream`, but in using a `UnixConnector`, the underlying stream type is `UnixStream`.

By exporting the `UnixStream` type, I was unblocked to being able to describe my type (it's using some generics, hence the reason) and happily off to the races. I noticed that having this type be `pub` has come up before, so if this looks like a good approach I'm happy to alter/add/amend this change to upstream it.

Thank you so much! 🎉 

Resolves #50

