### PR TITLE
Dependency segmentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 hex = "0.4"
 hyper = { version = "0.14", features = ["server", "client", "http1", "runtime"] }
 tokio = { version = "1.0", features = ["rt-multi-thread", "net"] }
-pin-project = "1.0"
+pin-project-lite = "0.2"
 futures-util = "0.3"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-futures-util = "0.3"
+futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 hex = "0.4"
 hyper = "0.14"
 tokio = { version = "1.0", features = ["net"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,16 +11,34 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-hex = "0.4"
-hyper = { version = "0.14", features = ["server", "client", "http1", "runtime"] }
-tokio = { version = "1.0", features = ["rt-multi-thread", "net"] }
-pin-project-lite = "0.2"
 futures-util = "0.3"
+hex = "0.4"
+hyper = "0.14"
+tokio = { version = "1.0", features = ["net"] }
+pin-project-lite = "0.2"
 
 [dev-dependencies]
-tokio = { version = "1.0", features = ["rt-multi-thread", "net", "macros", "io-std", "io-util"] }
+tokio = { version = "1.0", features = ["io-std", "io-util", "macros", "rt-multi-thread"] }
 
 [features]
-client = []
-server = []
-default = ["client", "server"]
+default = []
+client = [
+    "hyper/client",
+    "hyper/http1",
+]
+server = [
+    "hyper/http1",
+    "hyper/server"
+]
+
+[[example]]
+name = "client"
+required-features = ["client", "hyper/runtime"]
+
+[[example]]
+name = "server"
+required-features = ["server", "hyper/runtime"]
+
+[[test]]
+name = "server_client"
+required-features = ["client", "server", "hyper/runtime"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 hex = "0.4"
 hyper = "0.14"
 tokio = { version = "1.0", features = ["net"] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,7 +5,7 @@ use hyper::{
     service::Service,
     Body, Client, Uri,
 };
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::{
     io,
     path::{Path, PathBuf},
@@ -14,11 +14,12 @@ use std::{
 };
 use tokio::io::ReadBuf;
 
-#[pin_project]
-#[derive(Debug)]
-pub struct UnixStream {
-    #[pin]
-    unix_stream: tokio::net::UnixStream,
+pin_project! {
+    #[derive(Debug)]
+    pub struct UnixStream {
+        #[pin]
+        unix_stream: tokio::net::UnixStream,
+    }
 }
 
 impl UnixStream {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,3 @@
-use futures_util::future::BoxFuture;
 use hex::FromHex;
 use hyper::{
     client::connect::{Connected, Connection},
@@ -8,6 +7,7 @@ use hyper::{
 use pin_project_lite::pin_project;
 use std::{
     io,
+    future::Future,
     path::{Path, PathBuf},
     pin::Pin,
     task::{Context, Poll},
@@ -81,7 +81,7 @@ impl Unpin for UnixConnector {}
 impl Service<Uri> for UnixConnector {
     type Response = UnixStream;
     type Error = std::io::Error;
-    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
     fn call(&mut self, req: Uri) -> Self::Future {
         let fut = async move {
             let path = parse_socket_path(req)?;

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,7 +5,6 @@ use hyper::server::{Builder, Server};
 use conn::SocketIncoming;
 
 pub(crate) mod conn {
-    use futures_util::ready;
     use hyper::server::accept::Accept;
     use pin_project_lite::pin_project;
     use std::{
@@ -51,8 +50,8 @@ pub(crate) mod conn {
             self: Pin<&mut Self>,
             cx: &mut Context<'_>,
         ) -> Poll<Option<Result<Self::Conn, Self::Error>>> {
-            let conn = ready!(self.listener.poll_accept(cx))?.0;
-            Poll::Ready(Some(Ok(conn)))
+            self.listener.poll_accept(cx)?
+                .map(|(conn, _)| Some(Ok(conn)))
         }
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,7 +7,7 @@ use conn::SocketIncoming;
 pub(crate) mod conn {
     use futures_util::ready;
     use hyper::server::accept::Accept;
-    use pin_project::pin_project;
+    use pin_project_lite::pin_project;
     use std::{
         io,
         path::Path,
@@ -16,11 +16,12 @@ pub(crate) mod conn {
     };
     use tokio::net::{UnixListener, UnixStream};
 
-    /// A stream of connections from binding to a socket.
-    #[pin_project]
-    #[derive(Debug)]
-    pub struct SocketIncoming {
-        listener: UnixListener,
+    pin_project! {
+        /// A stream of connections from binding to a socket.
+        #[derive(Debug)]
+        pub struct SocketIncoming {
+            listener: UnixListener,
+        }
     }
 
     impl SocketIncoming {


### PR DESCRIPTION
This PR is technically comprised of three changes.  Since the changes are small individually, they are bundled together here.  I can split the changes into separate PRs if that is preferred.

The main motivation of this PR is to segment `hyper`'s server and client features into `hyperlocal`'s server and client features. 
 This helps reduce compile times for dependents only needing one of the features.  To further reduce compile times, this PR also exchanges `pin-project` for `pin-project-lite` and removes the `futures-util` dependency: `pin-project-lite` is used over `pin-project` in `tokio`, and Rust `std::future` is now standard enough to accomplish what is included from `futures-util`.

Some basic timings (`cargo clean` before each run):
| command | base | change |
|:----|:----|:-----|
| `cargo build --no-default-features --features=client` | 18.04s | 15.58s |
| `cargo build --no-default-features --features=server` | 17.84s | 15.32s |
| `cargo build --all-features` | 18.88s | 16.19s |