### PR TITLE
Export `UnixStream` for clients

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -15,6 +15,7 @@ use std::{
 use tokio::io::ReadBuf;
 
 pin_project! {
+    /// Wrapper around [`tokio::net::UnixStream`].
     #[derive(Debug)]
     pub struct UnixStream {
         #[pin]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 #[cfg(feature = "client")]
 mod client;
 #[cfg(feature = "client")]
-pub use client::{UnixClientExt, UnixConnector};
+pub use client::{UnixClientExt, UnixConnector, UnixStream};
 
 #[cfg(feature = "server")]
 mod server;


### PR DESCRIPTION
Update of #53. Resolves #50.