### PR TITLE
Adding support for UnixStream to take advantage of vectored writes

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -45,6 +45,18 @@ impl tokio::io::AsyncWrite for UnixStream {
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
         self.project().unix_stream.poll_shutdown(cx)
     }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<Result<usize, Error>> {
+        self.project().unix_stream.poll_write_vectored(cx)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.project().unix_stream.is_write_vectored()
+    }
 }
 
 impl tokio::io::AsyncRead for UnixStream {


### PR DESCRIPTION
If one checks UnixStream source code, they will see that is_write_vectored is equal to true.
https://docs.rs/tokio/latest/src/tokio/net/unix/stream.rs.html#982