### PR TITLE
Update readme to reflect lack of server extension trait after upgrade to hyper 1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,10 @@ u<div align="center">
 Hyper is a rock solid [Rust](https://www.rust-lang.org/) HTTP client and server toolkit.
 [Unix domain sockets](https://en.wikipedia.org/wiki/Unix_domain_socket) provide a mechanism
 for host-local interprocess communication. `hyperlocal` builds on and complements Hyper's
-interfaces for building Unix domain socket HTTP clients and servers.
+interfaces for building Unix domain socket HTTP clients.
 
-This is useful for exposing simple HTTP interfaces for your Unix daemons in cases where you
-want to limit access to the current host, in which case, opening and exposing tcp ports is
-not needed. Examples of Unix daemons that provide this kind of host local interface include
+This is useful for accessing HTTP interfaces exposed via a Unix daemons.
+Examples of Unix daemons that provide this kind of host local interface include
 [Docker](https://docs.docker.com/engine/misc/), a process container manager.
 
 ## Installation
@@ -68,12 +67,14 @@ $ curl --unix-socket /tmp/hyperlocal.sock localhost
 It's a Unix system. I know this.
 ```
 
+Note that `hyperlocal` is not required to build a server, though `hyper` and `tokio` are both used in the example.
+
 ### Clients
 
-`hyperlocal` also provides bindings for writing unix domain socket based HTTP clients the `Client` interface from the
+`hyperlocal` provides bindings for writing unix domain socket based HTTP clients the `Client` interface from the
 `hyper-utils` crate.
 
-An example is at [examples/client.rs](./examples/client.rs), runnable via `cargo run --features="server" --example client`
+An example is at [examples/client.rs](./examples/client.rs), runnable via `cargo run --example client`
 
 Hyper's client interface makes it easy to send typical HTTP methods like `GET`, `POST`, `DELETE` with factory
 methods, `get`, `post`, `delete`, etc. These require an argument that can be tranformed into a `hyper::Uri`.
@@ -81,6 +82,21 @@ methods, `get`, `post`, `delete`, etc. These require an argument that can be tra
 Since Unix domain sockets aren't represented with hostnames that resolve to ip addresses coupled with network ports,
 your standard over the counter URL string won't do. Instead, use a `hyperlocal::Uri`, which represents both file path to the domain
 socket and the resource URI path and query string.
+
+## Recent Releases of `hyperlocal`
+
+### 0.9
+
+Supports `hyper 1.x` by providing a `tower` service `UnixConnector` and an
+extension method `hyper_util::client::legacy::Client::unix()` to create a
+client. 
+
+The server extension method `bind_unix` was removed since there is no longer
+an equivalent to `hyper::Server`.
+
+### 0.8
+
+Supports `hyper 0.14` and provided extensions to both hyper's `Client` and `Server` via traits.
 
 ---
 


### PR DESCRIPTION
`hyperlocal` had an extension method of hyper's `Server` - but `Server` no longer exists in `hyper 1.0`, so that extension was removed in a pre-release version of `hyperlocal` 0.9.

This makes a correction to the README to reflect the removal of the extension trait.

This PR is one of two potential resolutions to https://github.com/softprops/hyperlocal/issues/70, the other being https://github.com/softprops/hyperlocal/pull/72.