### PR TITLE
Return an error if path is invalid

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -7,7 +7,7 @@ use tokio::io::{self, AsyncWriteExt as _};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
-    let url = Uri::new("/tmp/hyperlocal.sock", "/").into();
+    let url = Uri::new("/tmp/hyperlocal.sock", "/").unwrap().into();
 
     let client: Client<UnixConnector, Full<Bytes>> = Client::unix();
 

--- a/tests/server_client.rs
+++ b/tests/server_client.rs
@@ -43,7 +43,7 @@ async fn test_server_client() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let client: Client<UnixConnector, Full<Bytes>> = Client::unix();
 
-    let url = Uri::new(path, "/").into();
+    let url = Uri::new(path, "/").unwrap().into();
 
     let mut response = client.get(url).await?;
     let mut bytes = Vec::default();


### PR DESCRIPTION
Instead of panicking when a path is invalid, return an error which can properly be handled by the caller.

Note that this is a backwards-incompatible change, so the next version should be 0.10.0. Updating call-sites is usually trivial.